### PR TITLE
[Feature Request] Add events that can be send from viewModel into screen using Channel

### DIFF
--- a/src/main/resources/fileTemplates/internal/ComposeContract.kt.ft
+++ b/src/main/resources/fileTemplates/internal/ComposeContract.kt.ft
@@ -11,6 +11,13 @@ import androidx.compose.runtime.staticCompositionLocalOf
 class ${NAME}State
 
 /**
+ * UI Event that represents ${NAME}Screen
+**/
+sealed class ${NAME}Event {
+
+}
+
+/**
  * ${NAME} Actions emitted from the UI Layer
  * passed to the coordinator to handle
 **/

--- a/src/main/resources/fileTemplates/internal/ComposeCoordinator.kt.ft
+++ b/src/main/resources/fileTemplates/internal/ComposeCoordinator.kt.ft
@@ -13,6 +13,8 @@ class ${NAME}Coordinator(
 ) {
     val screenStateFlow = viewModel.stateFlow
 
+    val screenEventFlow = viewModel.eventFlow
+
     fun doStuff() {
         // TODO Handle UI Action
     }

--- a/src/main/resources/fileTemplates/internal/ComposeRoute.kt.ft
+++ b/src/main/resources/fileTemplates/internal/ComposeRoute.kt.ft
@@ -22,6 +22,15 @@ fun ${NAME}Route(
     // UI Actions
     val actions = remember${NAME}Actions(coordinator)
 
+    // Handle event
+    LaunchedEffect(Unit) {
+        coordinator.screenEventFlow.collect {
+            when (event) {
+                
+            }
+        }
+    }
+
     // UI Rendering
     ${NAME}Screen(uiState, actions)
 }

--- a/src/main/resources/fileTemplates/internal/ComposeViewModel.kt.ft
+++ b/src/main/resources/fileTemplates/internal/ComposeViewModel.kt.ft
@@ -13,6 +13,10 @@ class ${NAME}ViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle
 ) : ViewModel() {
 
+    private val _eventFlow = Channel<${NAME}Event>()
+    
+    val eventFlow = _eventFlow.receiveAsFlow()
+
     private val _stateFlow: MutableStateFlow<${NAME}State> = MutableStateFlow(${NAME}State())
   
     val stateFlow: StateFlow<${NAME}State> = _stateFlow.asStateFlow()


### PR DESCRIPTION
I will use SignIn as an example. I need to send actions from viewmodel so the SignInRoute will have parameter `navigateToDashboard`
```kotlin
@Composable
fun SignInRoute(
    coordinator: SignInCoordinator = rememberSignInCoordinator(),
    navigateToDashboard: () -> Unit = {}
) {
    ...

    // This code below might need to be move into another file i guess
    LaunchedEffect(Unit) {
        coordinator.screenEventFlow.collect { event ->
            when (event) {
                SignInEvent.SignedIn -> navigateToDashboard()
                is SignInEvent.ShowToast -> {
                    val message = event.message
                    // show toast
                }
            }
        }
    }
}
```

I know we can use existing UiState but it is stateflow which can be called again if there any configuration changes. Channel has different property. You might want to consider use SharedFlow instead for events