### PR TITLE
Create PreviewParameterProvider

### DIFF
--- a/src/main/kotlin/com/levinzonr/arch/jetpackcompose/plugin/core/PropertyKeys.kt
+++ b/src/main/kotlin/com/levinzonr/arch/jetpackcompose/plugin/core/PropertyKeys.kt
@@ -4,5 +4,6 @@ object PropertyKeys {
     const val PackageName = "PACKAGE_NAME"
     const val Name = "NAME"
     const val UseFlowWithLifecycle = "USE_FLOW_WITH_LIFECYCLE"
+    const val UsePreviewParameterProvider = "USE_PREVIEW_PARAMETER_PROVIDER"
     const val VIEW_MODEL_INJECTION = "VIEW_MODEL_INJECTION"
 }

--- a/src/main/kotlin/com/levinzonr/arch/jetpackcompose/plugin/features/newfeature/domain/FeatureConfiguration.kt
+++ b/src/main/kotlin/com/levinzonr/arch/jetpackcompose/plugin/features/newfeature/domain/FeatureConfiguration.kt
@@ -2,5 +2,6 @@ package com.levinzonr.arch.jetpackcompose.plugin.features.newfeature.domain
 
 data class FeatureConfiguration(
     val useCollectFlowWithLifecycle: Boolean,
+    val usePreviewParameterProvider: Boolean,
     val injection: InjectionConfiguration
 )

--- a/src/main/kotlin/com/levinzonr/arch/jetpackcompose/plugin/features/newfeature/domain/FeatureConfigurationRepository.kt
+++ b/src/main/kotlin/com/levinzonr/arch/jetpackcompose/plugin/features/newfeature/domain/FeatureConfigurationRepository.kt
@@ -10,6 +10,7 @@ class FeatureConfigurationRepository(
         dataSource.apply {
             put(KEY_INJECTION, features.injection.name)
             put(KEY_FLOW_LIFECYCLE, features.useCollectFlowWithLifecycle)
+            put(KEY_PREVIEW_PARAMETER_PROVIDER, features.usePreviewParameterProvider)
         }
     }
 
@@ -17,6 +18,7 @@ class FeatureConfigurationRepository(
         val injection = dataSource.get(KEY_INJECTION, InjectionConfiguration.Hilt.name)
         return FeatureConfiguration(
             useCollectFlowWithLifecycle = dataSource.get(KEY_FLOW_LIFECYCLE, true),
+            usePreviewParameterProvider = dataSource.get(KEY_PREVIEW_PARAMETER_PROVIDER, true),
             injection = InjectionConfiguration.valueOf(injection)
         )
     }
@@ -27,6 +29,7 @@ class FeatureConfigurationRepository(
 
     companion object {
         private const val KEY_FLOW_LIFECYCLE = "use_flow_with_lifecycle"
+        private const val KEY_PREVIEW_PARAMETER_PROVIDER = "use_preview_parameter_provider"
         private const val KEY_INJECTION = "view_model_injection"
     }
 }

--- a/src/main/kotlin/com/levinzonr/arch/jetpackcompose/plugin/features/newfeature/ui/ComposeArchDialogViewModel.kt
+++ b/src/main/kotlin/com/levinzonr/arch/jetpackcompose/plugin/features/newfeature/ui/ComposeArchDialogViewModel.kt
@@ -44,6 +44,9 @@ class ComposeArchDialogViewModel(
             generator.generateKt("ComposeViewModel", "${name}ViewModel", featPackage, properties)
             generator.generateKt("ComposeCoordinator", "${name}Coordinator", featPackage, properties)
             generator.generateKt("ComposeRoute", "${name}Route", featPackage, properties)
+            if (properties[PropertyKeys.UsePreviewParameterProvider] == true) {
+                generator.generateKt("ComposeStatePreviewParameterProvider", "${name}StatePreviewParameterProvider", featPackage, properties)
+            }
 
             if (featPackage.findSubdirectory("components") == null) {
                 featPackage.createSubdirectory("components")

--- a/src/main/kotlin/com/levinzonr/arch/jetpackcompose/plugin/features/newfeature/ui/ComposeArchDialogViewModel.kt
+++ b/src/main/kotlin/com/levinzonr/arch/jetpackcompose/plugin/features/newfeature/ui/ComposeArchDialogViewModel.kt
@@ -34,6 +34,7 @@ class ComposeArchDialogViewModel(
         val properties = mutableMapOf<String, Any>(
             PropertyKeys.Name to name,
             PropertyKeys.UseFlowWithLifecycle to config.useCollectFlowWithLifecycle,
+            PropertyKeys.UsePreviewParameterProvider to config.usePreviewParameterProvider,
             PropertyKeys.VIEW_MODEL_INJECTION to config.injection.name
         )
         application.runWriteAction {

--- a/src/main/kotlin/com/levinzonr/arch/jetpackcompose/plugin/features/newfeature/ui/advanced/AdvancedDialog.kt
+++ b/src/main/kotlin/com/levinzonr/arch/jetpackcompose/plugin/features/newfeature/ui/advanced/AdvancedDialog.kt
@@ -25,6 +25,13 @@ class AdvancedDialog(
                 }
                 row { comment("Collect the flow in the Route component in a lifecycle aware way") }
             }
+            group("Preview Parameter") {
+                row {
+                    checkBox("Use PreviewParameterProvider")
+                        .bindSelected(viewModel::usePreviewParameterProvider)
+                }
+                row { comment("Add a PreviewParameterProvider that can be used in the Composable function.") }
+            }
             group("ViewModel Injection") {
                 buttonsGroup {
                     row {

--- a/src/main/kotlin/com/levinzonr/arch/jetpackcompose/plugin/features/newfeature/ui/advanced/AdvancedDialog.kt
+++ b/src/main/kotlin/com/levinzonr/arch/jetpackcompose/plugin/features/newfeature/ui/advanced/AdvancedDialog.kt
@@ -30,7 +30,7 @@ class AdvancedDialog(
                     checkBox("Use PreviewParameterProvider")
                         .bindSelected(viewModel::usePreviewParameterProvider)
                 }
-                row { comment("Add a PreviewParameterProvider that can be used in the Composable function.") }
+                row { comment("Also generate a PreviewParameterProvider to preview various States in a Screen component.") }
             }
             group("ViewModel Injection") {
                 buttonsGroup {

--- a/src/main/kotlin/com/levinzonr/arch/jetpackcompose/plugin/features/newfeature/ui/advanced/AdvancedViewModel.kt
+++ b/src/main/kotlin/com/levinzonr/arch/jetpackcompose/plugin/features/newfeature/ui/advanced/AdvancedViewModel.kt
@@ -14,6 +14,13 @@ class AdvancedViewModel(
             featureConfigurationRepository.put(current.copy(useCollectFlowWithLifecycle = value))
         }
 
+    var usePreviewParameterProvider: Boolean
+        get() = featureConfigurationRepository.get().usePreviewParameterProvider
+        set(value) {
+            val current = featureConfigurationRepository.get()
+            featureConfigurationRepository.put(current.copy(usePreviewParameterProvider = value))
+        }
+
 
     private var injectionConfig
         get() = featureConfigurationRepository.get().injection

--- a/src/main/resources/fileTemplates/internal/ComposeContract.kt.ft
+++ b/src/main/resources/fileTemplates/internal/ComposeContract.kt.ft
@@ -3,9 +3,6 @@ package ${PACKAGE_NAME}
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.staticCompositionLocalOf
-#if (${USE_PREVIEW_PARAMETER_PROVIDER} == "true")
-import androidx.compose.ui.tooling.preview.PreviewParameterProvider
-#end
 
 /**
  * UI State that represents ${NAME}Screen
@@ -19,15 +16,3 @@ class ${NAME}State
 data class ${NAME}Actions(
     val onClick: () -> Unit = {}
 )
-
-#if (${USE_PREVIEW_PARAMETER_PROVIDER} == "true")
-/**
- * Create ${NAME}PreviewParameterProvider for ${NAME}ScreenPreview
-**/
-class ${NAME}StatePreviewParameterProvider : PreviewParameterProvider<${NAME}State> {
-    override val values: Sequence<${NAME}State>
-        get() = sequenceOf(
-
-        )
-}
-#end

--- a/src/main/resources/fileTemplates/internal/ComposeContract.kt.ft
+++ b/src/main/resources/fileTemplates/internal/ComposeContract.kt.ft
@@ -3,7 +3,9 @@ package ${PACKAGE_NAME}
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.staticCompositionLocalOf
-
+#if (${USE_PREVIEW_PARAMETER_PROVIDER} == "true")
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+#end
 
 /**
  * UI State that represents ${NAME}Screen
@@ -17,3 +19,15 @@ class ${NAME}State
 data class ${NAME}Actions(
     val onClick: () -> Unit = {}
 )
+
+#if (${USE_PREVIEW_PARAMETER_PROVIDER} == "true")
+/**
+ * Create ${NAME}PreviewParameterProvider for ${NAME}ScreenPreview
+**/
+class ${NAME}StatePreviewParameterProvider : PreviewParameterProvider<${NAME}State> {
+    override val values: Sequence<${NAME}State>
+        get() = sequenceOf(
+
+        )
+}
+#end

--- a/src/main/resources/fileTemplates/internal/ComposeScreen.kt.ft
+++ b/src/main/resources/fileTemplates/internal/ComposeScreen.kt.ft
@@ -2,6 +2,8 @@ package $PACKAGE_NAME
 
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
+#if (${USE_PREVIEW_PARAMETER_PROVIDER} == "true")import androidx.compose.ui.tooling.preview.PreviewParameter
+#end
 
 @Composable
 fun ${NAME}Screen(

--- a/src/main/resources/fileTemplates/internal/ComposeScreen.kt.ft
+++ b/src/main/resources/fileTemplates/internal/ComposeScreen.kt.ft
@@ -13,7 +13,7 @@ fun ${NAME}Screen(
 
 @Composable
 @Preview(name = "${NAME}")
-private fun ${NAME}ScreenPreview() {
+private fun ${NAME}ScreenPreview(#if (${USE_PREVIEW_PARAMETER_PROVIDER} == "true") @PreviewParameter(${NAME}StatePreviewParameterProvider::class) ${NAME}: ${NAME}State #end) {
     ${NAME}Screen(
         state = ${NAME}State(),
         actions = ${NAME}Actions()

--- a/src/main/resources/fileTemplates/internal/ComposeScreen.kt.ft
+++ b/src/main/resources/fileTemplates/internal/ComposeScreen.kt.ft
@@ -13,12 +13,25 @@ fun ${NAME}Screen(
   // TODO UI Rendering
 }
 
+#if (${USE_PREVIEW_PARAMETER_PROVIDER} == "true")
 @Composable
 @Preview(name = "${NAME}")
-private fun ${NAME}ScreenPreview(#if (${USE_PREVIEW_PARAMETER_PROVIDER} == "true") @PreviewParameter(${NAME}StatePreviewParameterProvider::class) ${NAME}: ${NAME}State #end) {
+private fun ${NAME}ScreenPreview(
+    @PreviewParameter(${NAME}StatePreviewParameterProvider::class)
+    ${NAME}: ${NAME}State
+) {
     ${NAME}Screen(
         state = ${NAME}State(),
         actions = ${NAME}Actions()
     )
 }
-
+#else
+@Composable
+@Preview(name = "${NAME}")
+private fun ${NAME}ScreenPreview() {
+    ${NAME}Screen(
+        state = ${NAME}State(),
+        actions = ${NAME}Actions()
+    )
+}
+#end

--- a/src/main/resources/fileTemplates/internal/ComposeStatePreviewParameterProvider.kt.ft
+++ b/src/main/resources/fileTemplates/internal/ComposeStatePreviewParameterProvider.kt.ft
@@ -1,0 +1,13 @@
+package ${PACKAGE_NAME}
+
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+
+/**
+ * Create ${NAME}PreviewParameterProvider for ${NAME}ScreenPreview
+**/
+class ${NAME}StatePreviewParameterProvider : PreviewParameterProvider<${NAME}State> {
+    override val values: Sequence<${NAME}State>
+        get() = sequenceOf(
+
+        )
+}

--- a/src/main/resources/liveTemplates/ComposeUIArch.xml
+++ b/src/main/resources/liveTemplates/ComposeUIArch.xml
@@ -11,4 +11,14 @@
         </context>
     </template>
 
+    <template
+        name="compara" value="@androidx.compose.ui.tooling.preview.PreviewParameterProvider&#10;class $NAME$StatePreviewParameterProvider : PreviewParameterProvider&#60;$NAME$State&#62; {&#10; override val values: Sequence&#60;$NAME$State&#62;&#10;get() = sequenceOf(&#10;&#10;)&#10;}"
+        description="Create a new PreviewParameterProvider"
+        toReformat="true"
+        toShortenFQNames="true">
+        <variable name="NAME" expression="" defaultValue="" alwaysStopAt="true"/>
+        <context>
+            <option name="com.levinzonr.compose.livetemplate.context" value="true"/>
+        </context>
+    </template>
 </templateSet>

--- a/src/main/resources/liveTemplates/ComposeUIArch.xml
+++ b/src/main/resources/liveTemplates/ComposeUIArch.xml
@@ -12,7 +12,7 @@
     </template>
 
     <template
-        name="compara" value="@androidx.compose.ui.tooling.preview.PreviewParameterProvider&#10;class $NAME$StatePreviewParameterProvider : PreviewParameterProvider&#60;$NAME$State&#62; {&#10; override val values: Sequence&#60;$NAME$State&#62;&#10;get() = sequenceOf(&#10;&#10;)&#10;}"
+        name="ppp" value="@androidx.compose.ui.tooling.preview.PreviewParameterProvider&#10;class $NAME$StatePreviewParameterProvider : PreviewParameterProvider&#60;$NAME$State&#62; {&#10; override val values: Sequence&#60;$NAME$State&#62;&#10;get() = sequenceOf(&#10;&#10;)&#10;}"
         description="Create a new PreviewParameterProvider"
         toReformat="true"
         toShortenFQNames="true">


### PR DESCRIPTION
#19
First of all, thank you for accepting my requirements.
The following features have been added to this PR.

## Add live template about PreviewParameterProvider
Enter 'compara' to create PreviewParameterProvider class.
```kotlin
class XXXStatePreviewParameterProvider : PreviewParameterProvider<XXXState> {
    override val values: Sequence<XXXState>
        get() = sequenceOf(

        )
}
```

## Adding a Preview Parameter Item to the Advanced Dialog
![image](https://github.com/levinzonr/jetpack-compose-ui-arch-plugin/assets/28133324/953e1ab2-76aa-4386-9144-5a2c285f9afc)

#### Adding this option will add the following code.
```kotlin
// HomeContract.kt
// ...
import androidx.compose.ui.tooling.preview.PreviewParameterProvider

// ...

/**
 * Create HomePreviewParameterProvider for HomeScreenPreview
 **/
class HomeStatePreviewParameterProvider : PreviewParameterProvider<HomeState> {
    override val values: Sequence<HomeState>
        get() = sequenceOf(

        )
}
```

```kotlin
// HomeScreen.kt
// ...
import androidx.compose.ui.tooling.preview.Preview
import androidx.compose.ui.tooling.preview.PreviewParameter

// ...

@Composable
@Preview(name = "Home")
private fun HomeScreenPreview(@PreviewParameter(HomeStatePreviewParameterProvider::class) Home: HomeState) {
    HomeScreen(
        state = HomeState(),
        actions = HomeActions()
    )
}
```